### PR TITLE
Trim trait tokens for clean type output

### DIFF
--- a/content.js
+++ b/content.js
@@ -113,11 +113,14 @@
 
       // --- Basic Info ---
       finalJson.Challenge = String(monsterData.level);
-      const traits = monsterData.traits.split(',').map(t => t.split('|')[0]);
+      const traits = monsterData.traits
+        .split(',')
+        .map(t => t.split('|')[0].trim())
+        .filter(Boolean);
       const size = traits.find(t => ["Tiny", "Small", "Medium", "Large", "Huge", "Gargantuan"].includes(t)) || "";
       const type = traits.find(t => ["Dragon", "Humanoid", "Aberration", "Construct", "Undead", "Ooze", "Beast", "Fiend", "Elemental"].includes(t)) || "Creature";
       const subtypes = traits.filter(t => ![size, type, "Uncommon", "Rare", "Unique"].includes(t) && !/^[A-Z]{1,2}$/.test(t));
-      finalJson.Type = `${size} ${type.toLowerCase()}${subtypes.length > 0 ? ` (${subtypes.map(s => s.toLowerCase()).join(', ')})` : ''}`.trim();
+      finalJson.Type = `${size} ${type.toLowerCase()}${subtypes.length > 0 ? ` (${subtypes.map(s => s.trim().toLowerCase()).join(', ')})` : ''}`.trim();
       
       const statParagraphs = doc.querySelectorAll('p[class*="Stat-"]');
 


### PR DESCRIPTION
## Summary
- trim trait tokens while splitting to avoid whitespace affecting size and type matching
- ensure subtype names are trimmed prior to lower casing for clean type formatting

## Testing
- node - <<'NODE'
const monsterData = {
  traits: 'Unique, Dragon, Fire'
};
const traits = monsterData.traits
  .split(',')
  .map(t => t.split('|')[0].trim())
  .filter(Boolean);
const size = traits.find(t => ["Tiny", "Small", "Medium", "Large", "Huge", "Gargantuan"].includes(t)) || "";
const type = traits.find(t => ["Dragon", "Humanoid", "Aberration", "Construct", "Undead", "Ooze", "Beast", "Fiend", "Elemental"].includes(t)) || "Creature";
const subtypes = traits.filter(t => ![size, type, "Uncommon", "Rare", "Unique"].includes(t) && !/^[A-Z]{1,2}$/.test(t));
const typeString = `${size} ${type.toLowerCase()}${subtypes.length > 0 ? ` (${subtypes.map(s => s.trim().toLowerCase()).join(', ')})` : ''}`.trim();
console.log({traits, size, type, subtypes, typeString});
NODE

------
https://chatgpt.com/codex/tasks/task_e_68cb0d3fcf1c832fa30825e52f3f21f2